### PR TITLE
feat: ts/results-page implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import Header from "./components/Header";
 import UpcomingFightsPage from "./pages/UpcomingFightsPage";
 import PastFightsPage from "./pages/PastFightsPage";
+import ResultsPage from "./pages/ResultsPage";
 import ModelPage from "./pages/ModelPage";
 import AboutPage from "./pages/AboutPage";
 import PredictionsPage from "./pages/PredictionsPage";
@@ -18,6 +19,7 @@ function App() {
           <Route path="/" element={<UpcomingFightsPage />} />
           <Route path="/events/:event_id" element={<PredictionsPage />} />
           <Route path="past" element={<PastFightsPage />} />
+          <Route path="/past_events/:event_id" element={<ResultsPage />} />
           <Route path="model" element={<ModelPage />} />
           <Route path="about" element={<AboutPage />} />
           

--- a/src/data/fetchPastEventsResults.ts
+++ b/src/data/fetchPastEventsResults.ts
@@ -12,15 +12,22 @@ export type PastEventResult = {
     method: string;
     fighter1_win_odds: number;
     fighter2_win_odds: number;
+    model_correct: boolean;
 };
 
-export async function fetchUpcomingEvents(signal: AbortSignal) {
-    const { data, error } = await supabase
-        .from("past_events_view_public")
-        .select("*")
-        .order("event_date", { ascending: true })
-        // .limit(200)
-        .abortSignal(signal);
-    if (error) throw error;
-    return data ?? [];
+export async function fetchPastEventsResults(
+    eventId: string, signal: AbortSignal
+    ) : Promise<PastEventResult[]> {
+        
+    let query = supabase
+            .from("predicted_events_public")
+            .select("*")
+            .eq("event_id", eventId)
+            // .order("bout_order", { ascending: true });
+    
+        if (signal) query = query.abortSignal(signal);
+    
+        const { data, error } = await query;
+        if (error) throw error;
+        return (data ?? []) as PastEventResult[];
 }

--- a/src/data/fetchPastEventsResults.ts
+++ b/src/data/fetchPastEventsResults.ts
@@ -1,0 +1,26 @@
+import { supabase } from "../lib/supabaseClient";
+
+export type PastEventResult = {
+    fight_id: string;
+    event_id: string;
+    event_name: string;
+    event_date: string;
+    weight_class: string;
+    fighter1: string;
+    fighter2: string;
+    outcome: string;
+    method: string;
+    fighter1_win_odds: number;
+    fighter2_win_odds: number;
+};
+
+export async function fetchUpcomingEvents(signal: AbortSignal) {
+    const { data, error } = await supabase
+        .from("past_events_view_public")
+        .select("*")
+        .order("event_date", { ascending: true })
+        // .limit(200)
+        .abortSignal(signal);
+    if (error) throw error;
+    return data ?? [];
+}

--- a/src/data/fetchPastEventsResults.ts
+++ b/src/data/fetchPastEventsResults.ts
@@ -20,13 +20,13 @@ export async function fetchPastEventsResults(
     ) : Promise<PastEventResult[]> {
         
     let query = supabase
-            .from("predicted_events_public")
+            .from("past_events_results_view")
             .select("*")
             .eq("event_id", eventId)
             // .order("bout_order", { ascending: true });
     
         if (signal) query = query.abortSignal(signal);
-    
+        
         const { data, error } = await query;
         if (error) throw error;
         return (data ?? []) as PastEventResult[];

--- a/src/data/fetchUniquePastEvents.ts
+++ b/src/data/fetchUniquePastEvents.ts
@@ -8,10 +8,10 @@ export type PastEvent = {
 
 export async function fetchPastEvents(signal: AbortSignal) {
     const { data, error } = await supabase
-        .from("past_events_results_view")
+        .from("past_events_view_public")
         .select("*")
-        .order("event_date", { ascending: true })
-        // .limit(200)
+        .order("event_date", { ascending: false })
+        .limit(20)
         .abortSignal(signal);
     if (error) throw error;
     return data ?? [];

--- a/src/data/fetchUniquePastEvents.ts
+++ b/src/data/fetchUniquePastEvents.ts
@@ -1,0 +1,18 @@
+import { supabase } from "../lib/supabaseClient";
+
+export type PastEvent = {
+  event_id: string;
+  event_name: string;
+  event_date: string;
+};
+
+export async function fetchUpcomingEvents(signal: AbortSignal) {
+    const { data, error } = await supabase
+        .from("past_events_results_view")
+        .select("*")
+        .order("event_date", { ascending: true })
+        // .limit(200)
+        .abortSignal(signal);
+    if (error) throw error;
+    return data ?? [];
+}

--- a/src/data/fetchUniquePastEvents.ts
+++ b/src/data/fetchUniquePastEvents.ts
@@ -6,7 +6,7 @@ export type PastEvent = {
   event_date: string;
 };
 
-export async function fetchUpcomingEvents(signal: AbortSignal) {
+export async function fetchPastEvents(signal: AbortSignal) {
     const { data, error } = await supabase
         .from("past_events_results_view")
         .select("*")

--- a/src/pages/PastFightsPage.tsx
+++ b/src/pages/PastFightsPage.tsx
@@ -1,3 +1,58 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { fetchPastEvents, type PastEvent } from "../data/fetchUniquePastEvents";
+
 export default function PastFightsPage() {
-  return <h2>Past Fights & Performance</h2>;
+  const [rows, setRows] = useState<PastEvent[]>([]);
+  const [status, setStatus] = useState<"idle"|"loading"|"error"|"ready">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let done = false;
+
+    (async () => {
+      setStatus("loading");
+      setError(null);
+      try {
+        const data = await fetchPastEvents(controller.signal);
+        if (controller.signal.aborted || done) return;
+        setRows(data);
+        setStatus("ready");
+      } catch (err: any) {
+        if (err?.name === "AbortError" || /aborted/i.test(err?.message ?? "")) return;
+        if (done) return;
+        setError(err?.message ?? "Failed to load events");
+        setStatus("error");
+      }
+    })();
+
+    return () => {
+      done = true;
+      controller.abort();
+    };
+  }, []);
+  if (status === "loading") return <p>Loading past events...</p>;
+  if (status === "error") return <p style={{ color: "crimson" }}>{error}</p>;
+
+  return (
+  // <h2>Past Fights & Performance</h2>
+  <section>
+    <h2>Past Fight Predictions: </h2>
+    {rows.length === 0 ? (
+      <p>Error: No Past Fight Predictions Found. </p>
+    ) : (
+      <ul style = {{listStyle: "none", padding: 0, margin: "1rem 0"}}>
+        {rows.map((e) => (
+          <li key={e.event_id}>
+            <Link to={`/past_events/${encodeURIComponent(e.event_id)}`} style={{ textDecoration: "none" }} state = {{ event_name: e.event_name }}>
+              <div style={{ fontWeight: 600 }}>{e.event_name}</div>
+              <div style={{ opacity: 0.8 }}>{e.event_date}</div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+  );
 }

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -2,6 +2,18 @@ import { useEffect, useState } from "react";
 import { useParams, useLocation, Link } from "react-router-dom";
 import {fetchPastEventsResults, type PastEventResult} from "../data/fetchPastEventsResults";
 
+const getResultIcon = (correct: boolean | null, actual_winner: string | null, method: string) => {
+    if (correct === null) {
+        return <div><b>No Contest</b></div>;
+    }
+    return (
+        <>
+            <div><b>Actual winner: {actual_winner} by {method}</b></div>
+            <div>{correct ? "✔️" : "❌"}</div>
+        </>
+    );
+};
+
 export default function ResultsPage() {
     const { event_id } = useParams<{ event_id: string }>();
     const [rows, setRows] = useState<PastEventResult[]>([]);
@@ -41,13 +53,19 @@ export default function ResultsPage() {
     if (status === "loading") return <p>Loading Results...</p>;
     if (status === "error") return <p style={{ color: "crimson" }}>{error}</p>;
 
+    const total = rows.length;
+    const correct = rows.filter(f => f.model_correct).length;
+    const event_accuracy = total > 0 ? ((correct / total) * 100).toFixed(1) : null;
+
     return (
         <section>
             <Link to="/past" style={{ display: "inline-block", marginBottom: "1rem" }}>← Back</Link>
             <h2>{event_name} Results Compared to Model</h2>
             {rows.length === 0 ? (
-                <p>Model did not live predict this event.</p>
+                <p>Model did not predict this event live (event was used in either testing, training or calibration dataset)</p>
             ) : (
+                <>
+                <h3>Model Accuracy for this event: {correct}/{total} ({event_accuracy}%)</h3>
                 <ul style={{ listStyle: "none", padding: 0, margin: "1rem 0" }}>
                     {rows.map((f) => {
                         const f1 = f.fighter1;
@@ -57,18 +75,27 @@ export default function ResultsPage() {
                         const method = f.method;
                         const actual_winner = f.outcome;
                         const model_correct = f.model_correct;
-                        // const 
                         return (
                             <li key={f.fight_id}>
                                 <div style={{ marginBottom: "1rem" }}>
-                                    <div>Model Prediction: {f1} ({(p1 * 100).toFixed(1)}%) vs {f2} ({(p2 * 100).toFixed(1)}%)</div>
-                                    <div>Actual winner: {actual_winner} by {method}</div>
-                                    <div>{model_correct ? "✔️" : "❌"}</div>
+                                    {/* <div>Model Prediction: {f1} ({(p1 * 100).toFixed(1)}%) 
+                                        vs {f2} ({(p2 * 100).toFixed(1)}%)</div> */}
+                                    <div style={{ fontWeight: 700, fontSize: 18 }}>
+                                        <span style = {{color: p1>=p2 ? "green" : "inherit"}}>
+                                            {f1} ({(p1 * 100).toFixed(1)}%)
+                                        </span>
+                                        {" "}vs{" "}
+                                        <span style={{ color: p2>p1 ? "green" : "inherit" }}>
+                                            {f2} ({(p2 * 100).toFixed(1)}%)
+                                        </span>
+                                    </div>
+                                    <div>{getResultIcon(model_correct, actual_winner, method)}</div>
                                 </div>
                             </li>
                         );
                     })}
                 </ul>
+                </>
             )}
         </section>
     )

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from "react";
 import { useParams, useLocation, Link } from "react-router-dom";
-// import {fetchPredictionsByEvent, type PredictedFight} from "../data/fetchPredictions";
+import {fetchPredictionsByEvent, type PredictedFight} from "../data/fetchPredictions";
+
 export default function ResultsPage() {
+    const { event_id } = useParams<{ event_id: string }>();
+    const [rows, setRows] = useState<PredictedFight[]>([]);
+    const [status, setStatus] = useState<"idle"|"loading"|"error"|"ready">("idle");
+    const [error, setError] = useState<string | null>(null);
+
+    
     return (
         <section>
+            <Link to="/" style={{ display: "inline-block", marginBottom: "1rem" }}>← Back</Link>
             <p>MEOW?</p>
         </section>
     )

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { useParams, useLocation, Link } from "react-router-dom";
-import {fetchPredictionsByEvent, type PredictedFight} from "../data/fetchPredictions";
+import {fetchPastEventsResults, type PastEventResult} from "../data/fetchPastEventsResults";
 
 export default function ResultsPage() {
     const { event_id } = useParams<{ event_id: string }>();
-    const [rows, setRows] = useState<PredictedFight[]>([]);
+    const [rows, setRows] = useState<PastEventResult[]>([]);
     const [status, setStatus] = useState<"idle"|"loading"|"error"|"ready">("idle");
     const [error, setError] = useState<string | null>(null);
 
@@ -20,7 +20,7 @@ export default function ResultsPage() {
             setStatus("loading");
             setError(null);
             try {
-                const data = await fetchPredictionsByEvent(event_id, controller.signal);
+                const data = await fetchPastEventsResults(event_id, controller.signal);
                 setRows(data);
                 setStatus("ready");
             } catch (err: any) {
@@ -44,7 +44,32 @@ export default function ResultsPage() {
     return (
         <section>
             <Link to="/past" style={{ display: "inline-block", marginBottom: "1rem" }}>← Back</Link>
-            <h2>{event_name}Results Compared to Model</h2>
+            <h2>{event_name} Results Compared to Model</h2>
+            {rows.length === 0 ? (
+                <p>Model did not live predict this event.</p>
+            ) : (
+                <ul style={{ listStyle: "none", padding: 0, margin: "1rem 0" }}>
+                    {rows.map((f) => {
+                        const f1 = f.fighter1;
+                        const f2 = f.fighter2;
+                        const p1 = f.fighter1_win_odds;
+                        const p2 = f.fighter2_win_odds;
+                        const method = f.method;
+                        const actual_winner = f.outcome;
+                        const model_correct = f.model_correct;
+                        // const 
+                        return (
+                            <li key={f.fight_id}>
+                                <div style={{ marginBottom: "1rem" }}>
+                                    <div>Model Prediction: {f1} ({(p1 * 100).toFixed(1)}%) vs {f2} ({(p2 * 100).toFixed(1)}%)</div>
+                                    <div>Actual winner: {actual_winner} by {method}</div>
+                                    <div>{model_correct ? "✔️" : "❌"}</div>
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
         </section>
     )
 }

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -8,11 +8,43 @@ export default function ResultsPage() {
     const [status, setStatus] = useState<"idle"|"loading"|"error"|"ready">("idle");
     const [error, setError] = useState<string | null>(null);
 
-    
+    // use the current page location as a var
+    const location = useLocation();
+    const event_name = (location.state as { event_name?: string })?.event_name;
+
+    useEffect(() => {
+        const controller = new AbortController();
+        let done = false;
+        if (!event_id) return;
+        (async () => {
+            setStatus("loading");
+            setError(null);
+            try {
+                const data = await fetchPredictionsByEvent(event_id, controller.signal);
+                setRows(data);
+                setStatus("ready");
+            } catch (err: any) {
+                if (err?.name === "AbortError" || /aborted/i.test(err?.message ?? "")) return;
+                if (done) return;
+                setError(err?.message ?? "Failed to load model results");
+                setStatus("error");
+            }
+        })();
+
+        return()=> {
+            done=true;
+            controller.abort();
+        };
+    }, [event_id]);
+
+    if (!event_id) return <p>Invalid event id.</p>;
+    if (status === "loading") return <p>Loading Results...</p>;
+    if (status === "error") return <p style={{ color: "crimson" }}>{error}</p>;
+
     return (
         <section>
-            <Link to="/" style={{ display: "inline-block", marginBottom: "1rem" }}>← Back</Link>
-            <p>MEOW?</p>
+            <Link to="/past" style={{ display: "inline-block", marginBottom: "1rem" }}>← Back</Link>
+            <h2>{event_name}Results Compared to Model</h2>
         </section>
     )
 }

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+import { useParams, useLocation, Link } from "react-router-dom";
+// import {fetchPredictionsByEvent, type PredictedFight} from "../data/fetchPredictions";
+export default function ResultsPage() {
+    return (
+        <section>
+            <p>MEOW?</p>
+        </section>
+    )
+}


### PR DESCRIPTION
Implemented results page, implemented results view in the back end for the front end. Still need to implement a search functionality to instantly find any past predicted fight as the next to do. 